### PR TITLE
[codex] feat: add reverse DCF analytics

### DIFF
--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,27 +1,28 @@
-import pandas as pd
+from trg_workbench.reporting.pdf_renderer import render_html_report
 from trg_workbench.reporting.renderers import render_template
+
 
 def test_daily_template_renders_key_sections():
     content = render_template(
         "daily_note.md.j2",
         {
-            "report_title": "Daily Tactical Note", # Matches context['report_title']
-            "as_of_date": "2026-03-26",          # Matches context['as_of_date']
-            "us_macro_rows": [                   # Matches us_macro_rows in v2
+            "report_title": "Daily Tactical Note",  # Matches context['report_title']
+            "as_of_date": "2026-03-26",  # Matches context['as_of_date']
+            "us_macro_rows": [  # Matches us_macro_rows in v2
                 {
                     "label": "USD per EUR",
                     "value_fmt": "1.08",
                     "chg_1w": 0.01,
                 }
             ],
-            "sector_rows": [                     # Matches sector_rows in v2
+            "sector_rows": [  # Matches sector_rows in v2
                 {
                     "sector_name": "Technology",
                     "ticker": "XLK",
                     "ret_1w": 0.03,
                 }
             ],
-            "screen_rows": [                     # CRITICAL FIX: Changed from top_candidates
+            "screen_rows": [  # CRITICAL FIX: Changed from top_candidates
                 {
                     "ticker": "GS",
                     "company_name": "Goldman Sachs Group, Inc.",
@@ -30,6 +31,16 @@ def test_daily_template_renders_key_sections():
                 }
             ],
             "catalyst_rows": [],
+            "dcf_results": [
+                {
+                    "ticker": "GS",
+                    "reverse_dcf": {
+                        "implied_growth_rate": 0.12,
+                        "wacc": 0.09,
+                        "terminal_growth": 0.025,
+                    },
+                }
+            ],
             "tactical_takeaways": ["Financials are leading this week."],
         },
     )
@@ -37,3 +48,34 @@ def test_daily_template_renders_key_sections():
     assert "# Daily Tactical Note" in content
     assert "US Sector Tape" in content
     assert "Goldman Sachs Group, Inc." in content
+    assert "GS: market implies 12.0% FCF CAGR" in content
+
+
+def test_html_template_renders_reverse_dcf_section():
+    content = render_html_report(
+        {
+            "report_title": "Research Note",
+            "as_of_date": "2026-03-26",
+            "charts": {},
+            "dcf_results": [
+                {
+                    "ticker": "GS",
+                    "current_price": 100.0,
+                    "reverse_dcf": {
+                        "implied_growth_rate": 0.12,
+                        "implied_ev": 1_250_000_000,
+                        "projection_years": 10,
+                        "terminal_growth": 0.025,
+                        "wacc": 0.09,
+                        "sensitivity": {
+                            "wacc_down_100bps": {"implied_growth_rate": 0.10},
+                            "wacc_up_100bps": {"implied_growth_rate": 0.14},
+                        },
+                    },
+                }
+            ],
+        }
+    )
+
+    assert "Market-Implied FCF CAGR" in content
+    assert "12.0%" in content

--- a/tests/test_valuation.py
+++ b/tests/test_valuation.py
@@ -1,0 +1,46 @@
+import pytest
+
+from trg_workbench.analytics.valuation import dcf_valuation, reverse_dcf
+
+
+def test_reverse_dcf_recovers_known_growth_rate():
+    base_fcf = 100.0
+    growth_rate = 0.08
+    wacc = 0.10
+    terminal_growth = 0.03
+    shares = 10.0
+    net_debt = 50.0
+
+    forward_dcf = dcf_valuation(
+        base_fcf=base_fcf,
+        growth_rates=[growth_rate] * 10,
+        terminal_growth_rate=terminal_growth,
+        wacc=wacc,
+        net_debt=net_debt,
+        shares_outstanding=shares,
+    )
+
+    result = reverse_dcf(
+        current_price=forward_dcf["intrinsic_value_per_share"],
+        shares_outstanding=shares,
+        net_debt=net_debt,
+        base_fcf=base_fcf,
+        wacc=wacc,
+        terminal_growth=terminal_growth,
+    )
+
+    assert result["implied_growth_rate"] == pytest.approx(growth_rate, abs=0.001)
+    assert result["implied_ev"] > result["target_equity_value"]
+    assert set(result["sensitivity"]) == {"wacc_down_100bps", "base", "wacc_up_100bps"}
+
+
+def test_reverse_dcf_rejects_invalid_inputs():
+    with pytest.raises(ValueError):
+        reverse_dcf(
+            current_price=100.0,
+            shares_outstanding=10.0,
+            net_debt=0.0,
+            base_fcf=100.0,
+            wacc=0.03,
+            terminal_growth=0.03,
+        )

--- a/trg_workbench/analytics/valuation.py
+++ b/trg_workbench/analytics/valuation.py
@@ -5,9 +5,11 @@ football field data, bull/base/bear scenario valuations.
 """
 from __future__ import annotations
 
+from typing import Dict, List, Optional, Tuple
+
 import numpy as np
 import pandas as pd
-from typing import Dict, List, Optional, Tuple
+from scipy.optimize import brentq
 
 
 # ─── WACC estimation ──────────────────────────────────────────────────────────
@@ -120,6 +122,111 @@ def dcf_sensitivity(
     df = pd.DataFrame(results)
     df.index.name = "WACC"
     return df.round(2)
+
+
+def _enterprise_value_for_constant_growth(
+    base_fcf: float,
+    growth_rate: float,
+    wacc: float,
+    terminal_growth: float,
+    projection_years: int,
+) -> float:
+    if wacc <= terminal_growth:
+        raise ValueError("wacc must be greater than terminal_growth")
+
+    fcfs = [
+        base_fcf * (1 + growth_rate) ** year
+        for year in range(1, projection_years + 1)
+    ]
+    pv_fcfs = [
+        fcf / (1 + wacc) ** year
+        for year, fcf in enumerate(fcfs, start=1)
+    ]
+    terminal_value = fcfs[-1] * (1 + terminal_growth) / (wacc - terminal_growth)
+    pv_terminal = terminal_value / (1 + wacc) ** projection_years
+    return float(sum(pv_fcfs) + pv_terminal)
+
+
+def reverse_dcf(
+    current_price: float,
+    shares_outstanding: float,
+    net_debt: float,
+    base_fcf: float,
+    wacc: float,
+    terminal_growth: float,
+    projection_years: int = 10,
+) -> Dict:
+    """
+    Solve for the constant annual FCF growth rate implied by the current share price.
+
+    Returns a dict with the implied growth rate, target enterprise value, and
+    WACC sensitivity using +/- 100 bps around the base WACC.
+    """
+    if current_price <= 0:
+        raise ValueError("current_price must be positive")
+    if shares_outstanding <= 0:
+        raise ValueError("shares_outstanding must be positive")
+    if base_fcf <= 0:
+        raise ValueError("base_fcf must be positive")
+    if projection_years <= 0:
+        raise ValueError("projection_years must be positive")
+    if wacc <= terminal_growth:
+        raise ValueError("wacc must be greater than terminal_growth")
+
+    target_equity_value = current_price * shares_outstanding
+    implied_ev = target_equity_value + net_debt
+
+    def solve_for_wacc(discount_rate: float, *, allow_nan: bool = False) -> float:
+        if discount_rate <= terminal_growth:
+            return float("nan")
+
+        def objective(growth_rate: float) -> float:
+            return (
+                _enterprise_value_for_constant_growth(
+                    base_fcf=base_fcf,
+                    growth_rate=growth_rate,
+                    wacc=discount_rate,
+                    terminal_growth=terminal_growth,
+                    projection_years=projection_years,
+                )
+                - implied_ev
+            )
+
+        lower = -0.90
+        upper = 1.00
+        for candidate_upper in [upper, 1.50, 2.00, 3.00, 5.00]:
+            if objective(lower) * objective(candidate_upper) <= 0:
+                return float(brentq(objective, lower, candidate_upper))
+        if allow_nan:
+            return float("nan")
+        raise ValueError("could not bracket implied growth rate")
+
+    implied_growth_rate = solve_for_wacc(wacc)
+    sensitivity = {
+        "wacc_down_100bps": {
+            "wacc": round(wacc - 0.01, 4),
+            "implied_growth_rate": round(solve_for_wacc(wacc - 0.01, allow_nan=True), 4),
+        },
+        "base": {
+            "wacc": round(wacc, 4),
+            "implied_growth_rate": round(implied_growth_rate, 4),
+        },
+        "wacc_up_100bps": {
+            "wacc": round(wacc + 0.01, 4),
+            "implied_growth_rate": round(solve_for_wacc(wacc + 0.01, allow_nan=True), 4),
+        },
+    }
+
+    return {
+        "implied_growth_rate": round(implied_growth_rate, 4),
+        "implied_ev": round(implied_ev, 0),
+        "target_equity_value": round(target_equity_value, 0),
+        "current_price": current_price,
+        "wacc": wacc,
+        "terminal_growth": terminal_growth,
+        "projection_years": projection_years,
+        "sensitivity": sensitivity,
+    }
 
 
 # ─── comps / peer table ───────────────────────────────────────────────────────

--- a/trg_workbench/pipeline_v2.py
+++ b/trg_workbench/pipeline_v2.py
@@ -224,7 +224,11 @@ def build_research_report_v2(
     logger.info("Running valuation analytics...")
     dcf_results = []
     from trg_workbench.analytics.valuation import (
-        derive_dcf_inputs, dcf_sensitivity, football_field, scenario_analysis
+        derive_dcf_inputs,
+        dcf_sensitivity,
+        football_field,
+        reverse_dcf,
+        scenario_analysis,
     )
 
     _tc = "ticker" if "ticker" in top_candidates.columns else None
@@ -236,7 +240,8 @@ def build_research_report_v2(
             sec_row = fundamentals_df[fundamentals_df["ticker"] == ticker].iloc[0].to_dict() if ticker in fundamentals_df["ticker"].values else {}
             
             inputs = derive_dcf_inputs(sm_row, sec_row)
-            if inputs["base_fcf"] == 0: continue
+            if inputs["base_fcf"] == 0:
+                continue
 
             scenarios = scenario_analysis(inputs["base_fcf"], inputs["base_growth"], inputs["wacc"], inputs["net_debt"], inputs["shares_outstanding"])
             sensitivity_df = dcf_sensitivity(inputs["base_fcf"], [inputs["base_growth"] * (0.85 ** i) for i in range(5)], inputs["net_debt"], inputs["shares_outstanding"])
@@ -247,7 +252,31 @@ def build_research_report_v2(
                                 dcf_bull=scenarios["Bull Case"]["intrinsic_value_per_share"],
                                 dcf_bear=scenarios["Bear Case"]["intrinsic_value_per_share"])
 
-            dcf_results.append({"ticker": ticker, "inputs": inputs, "scenarios": scenarios, "sensitivity_df": sensitivity_df, "football_field": ff, "current_price": current_price})
+            reverse_dcf_result = None
+            if current_price > 0:
+                try:
+                    reverse_dcf_result = reverse_dcf(
+                        current_price=current_price,
+                        shares_outstanding=inputs["shares_outstanding"],
+                        net_debt=inputs["net_debt"],
+                        base_fcf=inputs["base_fcf"],
+                        wacc=inputs["wacc"],
+                        terminal_growth=scenarios["Base Case"]["tgr_used"],
+                    )
+                except ValueError as exc:
+                    logger.warning("Reverse DCF failed for %s: %s", ticker, exc)
+
+            dcf_results.append(
+                {
+                    "ticker": ticker,
+                    "inputs": inputs,
+                    "scenarios": scenarios,
+                    "sensitivity_df": sensitivity_df,
+                    "football_field": ff,
+                    "current_price": current_price,
+                    "reverse_dcf": reverse_dcf_result,
+                }
+            )
             
             if disable_prog:
                 logger.info("Valuation complete for %s (Base: $%.2f)", ticker, scenarios["Base Case"]["intrinsic_value_per_share"])
@@ -311,5 +340,12 @@ def build_research_report_v2(
     if "pdf" in output_formats:
         pdf_path = OUTPUTS_DIR / f"research_note_{as_of}.pdf"
         outputs["pdf"] = render_research_note_pdf(context, pdf_path, quiet=quiet)
+
+    if "markdown" in output_formats:
+        from trg_workbench.reporting.renderers import render_template, write_report
+
+        md_path = OUTPUTS_DIR / f"daily_note_{as_of}.md"
+        markdown = render_template("daily_note.md.j2", context)
+        outputs["markdown"] = write_report(md_path, markdown)
 
     return outputs

--- a/trg_workbench/reporting/templates/daily_note.md.j2
+++ b/trg_workbench/reporting/templates/daily_note.md.j2
@@ -38,6 +38,15 @@ Data as of: {{ as_of_date }}
 | {{ row.get("ticker", "") }} | {{ row.get("company_name", "") }} | {{ row.get("next_earnings_date", "") }} |
 {% endfor %}
 
+{% if dcf_results %}
+## Reverse DCF
+{% for row in dcf_results %}
+{% if row.reverse_dcf %}
+- {{ row.ticker }}: market implies {{ row.reverse_dcf.implied_growth_rate | pct }} FCF CAGR at {{ row.reverse_dcf.wacc | pct }} WACC and {{ row.reverse_dcf.terminal_growth | pct }} terminal growth.
+{% endif %}
+{% endfor %}
+
+{% endif %}
 {% if analyst_overlays %}
 ## Analyst Overlays
 {% for row in analyst_overlays %}

--- a/trg_workbench/reporting/templates/research_note.html.j2
+++ b/trg_workbench/reporting/templates/research_note.html.j2
@@ -598,6 +598,26 @@
 </div>
 {% endif %}
 
+{% if ticker_dcf.reverse_dcf %}
+<div class="metric-row">
+  <div class="metric-card">
+    <div class="mc-label">Market-Implied FCF CAGR</div>
+    <div class="mc-value">{{ ticker_dcf.reverse_dcf.implied_growth_rate | pct }}</div>
+    <div class="mc-sub">{{ ticker_dcf.reverse_dcf.projection_years }}Y projection | TGR {{ ticker_dcf.reverse_dcf.terminal_growth | pct }}</div>
+  </div>
+  <div class="metric-card">
+    <div class="mc-label">Implied Enterprise Value</div>
+    <div class="mc-value">{{ ticker_dcf.reverse_dcf.implied_ev | number }}</div>
+    <div class="mc-sub">Price: ${{ "%.2f"|format(ticker_dcf.current_price) }} | WACC {{ ticker_dcf.reverse_dcf.wacc | pct }}</div>
+  </div>
+  <div class="metric-card">
+    <div class="mc-label">WACC Sensitivity</div>
+    <div class="mc-value">{{ ticker_dcf.reverse_dcf.sensitivity.wacc_down_100bps.implied_growth_rate | pct }} / {{ ticker_dcf.reverse_dcf.sensitivity.wacc_up_100bps.implied_growth_rate | pct }}</div>
+    <div class="mc-sub">Implied growth at WACC -100bps / +100bps</div>
+  </div>
+</div>
+{% endif %}
+
 {% if charts["dcf_sensitivity_" + ticker_dcf.ticker] or charts["football_" + ticker_dcf.ticker] %}
 <div class="chart-grid">
   {% if charts["dcf_sensitivity_" + ticker_dcf.ticker] %}


### PR DESCRIPTION
## Summary

- Add `reverse_dcf()` to solve the constant FCF CAGR implied by the current share price using `scipy.optimize.brentq`
- Add WACC +/- 100 bps sensitivity to the reverse DCF output
- Wire reverse DCF into the v2 valuation pipeline for top valuation candidates
- Surface market-implied FCF CAGR in the HTML DCF section and Markdown daily note
- Add focused solver and template rendering tests

Closes #6

## Validation

- Ran `git diff --cached --check`
- Ran `C:\Users\Anklesh\anaconda3\python.exe -m pytest tests\test_valuation.py tests\test_reporting.py -q` -> `4 passed`
- Ran `C:\Users\Anklesh\anaconda3\python.exe -m pytest -q` -> `9 passed`

Note: one focused local pytest invocation printed a Windows Matplotlib access-violation stack after reporting success, then the full suite rerun completed cleanly with `9 passed`.