### PR TITLE
[codex] feat: add management commentary transcript MVP

### DIFF
--- a/tests/fixtures/sample_earnings_transcript.txt
+++ b/tests/fixtures/sample_earnings_transcript.txt
@@ -1,0 +1,5 @@
+Operator: Good afternoon and welcome to Alpha Co's earnings conference call.
+Management: Demand remained strong across enterprise customers, and we raised full-year revenue guidance by 3% as backlog conversion improved.
+Management: The new product launch is on track for the third quarter, and the board expanded the buyback authorization.
+Management: We continue to see FX headwinds in EMEA and margin pressure from hardware mix, but supply availability improved sequentially.
+Question-and-Answer Session: Analysts asked about durability of demand. Management said the pipeline remains constructive, although macro uncertainty could slow some small-business deals.

--- a/tests/test_llm_reasoning.py
+++ b/tests/test_llm_reasoning.py
@@ -1,0 +1,65 @@
+from datetime import date
+from pathlib import Path
+import shutil
+
+from trg_workbench.llm.chunker import chunk_text
+from trg_workbench.llm.pipeline import build_management_commentary
+from trg_workbench.llm.reasoner import analyze_transcript
+from trg_workbench.llm.retriever import retrieve_relevant_chunks
+from trg_workbench.llm.transcript_fetcher import clean_filing_text
+
+
+def _fixture_text() -> str:
+    return Path("tests/fixtures/sample_earnings_transcript.txt").read_text(encoding="utf-8")
+
+
+def test_chunker_preserves_overlap_between_chunks():
+    text = " ".join(f"Sentence {index} has enough words for chunking." for index in range(20))
+    chunks = chunk_text(text, max_words=25, overlap_words=5)
+
+    assert len(chunks) > 1
+    assert chunks[0].split()[-5:] == chunks[1].split()[:5]
+
+
+def test_retriever_prioritizes_keyword_chunks():
+    chunks = [
+        "Macro data stayed quiet.",
+        "Management raised guidance and discussed demand.",
+        "Closing remarks were short.",
+    ]
+
+    assert retrieve_relevant_chunks(chunks, ["guidance"], limit=1) == [chunks[1]]
+
+
+def test_clean_filing_text_strips_html_markup():
+    raw_html = "<html><script>ignore()</script><body><p>Operator &amp; management remarks.</p></body></html>"
+
+    assert clean_filing_text(raw_html) == "Operator & management remarks."
+
+
+def test_analyze_transcript_extracts_management_commentary():
+    result = analyze_transcript("AAA", _fixture_text())
+
+    assert result is not None
+    assert result["ticker"] == "AAA"
+    assert result["tone_score"] > 0.5
+    assert "raised full-year revenue guidance" in result["guidance_summary"]
+    assert result["key_risks"]
+    assert result["catalyst_flags"]
+    assert result["analyst_qa_tone"] == "constructive"
+
+
+def test_management_commentary_uses_cached_transcript_without_live_fetch():
+    cache_dir = Path("data/cache/test_transcripts")
+    shutil.rmtree(cache_dir, ignore_errors=True)
+    try:
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "AAA_latest.txt").write_text(_fixture_text(), encoding="utf-8")
+
+        rows = build_management_commentary(["AAA"], date(2026, 3, 27), cache_dir=cache_dir)
+
+        assert rows
+        assert rows[0]["ticker"] == "AAA"
+        assert rows[0]["transcript_source_url"] is None
+    finally:
+        shutil.rmtree(cache_dir, ignore_errors=True)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -41,6 +41,15 @@ def test_daily_template_renders_key_sections():
                     },
                 }
             ],
+            "management_commentary": [
+                {
+                    "ticker": "GS",
+                    "tone_score": 0.72,
+                    "guidance_summary": "Management raised guidance.",
+                    "key_risks": ["FX headwinds remain."],
+                    "catalyst_flags": ["New product launch in Q3."],
+                }
+            ],
             "tactical_takeaways": ["Financials are leading this week."],
         },
     )
@@ -49,6 +58,8 @@ def test_daily_template_renders_key_sections():
     assert "US Sector Tape" in content
     assert "Goldman Sachs Group, Inc." in content
     assert "GS: market implies 12.0% FCF CAGR" in content
+    assert "Management Commentary" in content
+    assert "Management raised guidance." in content
 
 
 def test_html_template_renders_reverse_dcf_section():
@@ -74,8 +85,20 @@ def test_html_template_renders_reverse_dcf_section():
                     },
                 }
             ],
+            "management_commentary": [
+                {
+                    "ticker": "GS",
+                    "tone_score": 0.72,
+                    "analyst_qa_tone": "constructive",
+                    "source": "heuristic_transcript_parser",
+                    "guidance_summary": "Management raised guidance.",
+                    "key_risks": ["FX headwinds remain."],
+                    "catalyst_flags": ["New product launch in Q3."],
+                }
+            ],
         }
     )
 
     assert "Market-Implied FCF CAGR" in content
     assert "12.0%" in content
+    assert "Management Commentary" in content

--- a/trg_workbench/llm/__init__.py
+++ b/trg_workbench/llm/__init__.py
@@ -1,0 +1,5 @@
+"""Transcript reasoning helpers for management commentary."""
+
+from trg_workbench.llm.reasoner import analyze_transcript
+
+__all__ = ["analyze_transcript"]

--- a/trg_workbench/llm/chunker.py
+++ b/trg_workbench/llm/chunker.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import re
+
+
+SENTENCE_RE = re.compile(r"(?<=[.!?])\s+(?=[A-Z0-9\"'])")
+
+
+def split_sentences(text: str) -> list[str]:
+    normalized = re.sub(r"\s+", " ", text or "").strip()
+    if not normalized:
+        return []
+    return [sentence.strip() for sentence in SENTENCE_RE.split(normalized) if sentence.strip()]
+
+
+def _word_chunks(words: list[str], max_words: int, overlap_words: int) -> list[str]:
+    chunks: list[str] = []
+    step = max(1, max_words - overlap_words)
+    for start in range(0, len(words), step):
+        chunk_words = words[start : start + max_words]
+        if chunk_words:
+            chunks.append(" ".join(chunk_words))
+    return chunks
+
+
+def chunk_text(text: str, max_words: int = 500, overlap_words: int = 50) -> list[str]:
+    if max_words <= 0:
+        raise ValueError("max_words must be positive")
+    if overlap_words < 0:
+        raise ValueError("overlap_words cannot be negative")
+    if overlap_words >= max_words:
+        raise ValueError("overlap_words must be smaller than max_words")
+
+    chunks: list[str] = []
+    current: list[str] = []
+    current_count = 0
+
+    for sentence in split_sentences(text):
+        words = sentence.split()
+        if len(words) > max_words:
+            if current:
+                chunks.append(" ".join(current))
+                current = current[-overlap_words:] if overlap_words else []
+                current_count = len(current)
+            chunks.extend(_word_chunks(words, max_words, overlap_words))
+            continue
+
+        if current and current_count + len(words) > max_words:
+            chunks.append(" ".join(current))
+            current = current[-overlap_words:] if overlap_words else []
+            current_count = len(current)
+
+        current.extend(words)
+        current_count += len(words)
+
+    if current:
+        chunks.append(" ".join(current))
+
+    return chunks

--- a/trg_workbench/llm/pipeline.py
+++ b/trg_workbench/llm/pipeline.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from trg_workbench.llm.reasoner import analyze_transcript
+from trg_workbench.llm.transcript_fetcher import SECEarningsTranscriptFetcher
+
+
+def build_management_commentary(
+    tickers: list[str],
+    as_of_date: date,
+    fetch_live: bool = False,
+    cache_dir: Path | None = None,
+) -> list[dict[str, object]]:
+    fetcher = SECEarningsTranscriptFetcher(cache_dir=cache_dir)
+    rows: list[dict[str, object]] = []
+
+    for ticker in tickers:
+        document = (
+            fetcher.fetch_latest(ticker, as_of_date=as_of_date)
+            if fetch_live
+            else fetcher.load_cached(ticker)
+        )
+        if document is None:
+            continue
+        analysis = analyze_transcript(ticker, document.text)
+        if analysis is None:
+            continue
+        analysis["transcript_source_url"] = document.source_url
+        analysis["transcript_filing_date"] = document.filing_date
+        rows.append(analysis)
+
+    return rows

--- a/trg_workbench/llm/reasoner.py
+++ b/trg_workbench/llm/reasoner.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+from trg_workbench.llm.chunker import chunk_text, split_sentences
+from trg_workbench.llm.retriever import retrieve_relevant_chunks
+
+
+POSITIVE_TERMS = [
+    "accelerate",
+    "beat",
+    "constructive",
+    "demand",
+    "expanded",
+    "growth",
+    "improved",
+    "margin expansion",
+    "raised",
+    "record",
+    "resilient",
+    "strong",
+    "upside",
+]
+NEGATIVE_TERMS = [
+    "challenge",
+    "decline",
+    "delayed",
+    "headwind",
+    "lowered",
+    "pressure",
+    "risk",
+    "slower",
+    "soft",
+    "uncertain",
+    "weak",
+]
+GUIDANCE_TERMS = ["guidance", "outlook", "raised", "lowered", "reaffirmed", "expects", "forecast"]
+RISK_TERMS = ["risk", "headwind", "pressure", "challenge", "uncertain", "weak", "decline", "slower"]
+CATALYST_TERMS = ["launch", "buyback", "repurchase", "approval", "new product", "expansion", "partnership"]
+
+
+@dataclass
+class ManagementCommentary:
+    ticker: str
+    tone_score: float
+    guidance_summary: str
+    key_risks: list[str]
+    catalyst_flags: list[str]
+    analyst_qa_tone: str
+    source: str = "heuristic_transcript_parser"
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def _term_count(text: str, terms: list[str]) -> int:
+    lower_text = text.lower()
+    return sum(lower_text.count(term) for term in terms)
+
+
+def _tone_score(text: str) -> float:
+    positive = _term_count(text, POSITIVE_TERMS)
+    negative = _term_count(text, NEGATIVE_TERMS)
+    if positive + negative == 0:
+        return 0.5
+    score = positive / (positive + negative)
+    return round(min(max(score, 0.0), 1.0), 2)
+
+
+def _tone_label(score: float) -> str:
+    if score >= 0.60:
+        return "constructive"
+    if score <= 0.40:
+        return "cautious"
+    return "balanced"
+
+
+def _matching_sentences(text: str, terms: list[str], limit: int) -> list[str]:
+    matches: list[str] = []
+    seen: set[str] = set()
+    for sentence in split_sentences(text):
+        lower_sentence = sentence.lower()
+        if any(term in lower_sentence for term in terms) and sentence not in seen:
+            matches.append(sentence)
+            seen.add(sentence)
+        if len(matches) >= limit:
+            break
+    return matches
+
+
+def _guidance_summary(text: str) -> str:
+    matches = _matching_sentences(text, GUIDANCE_TERMS, limit=1)
+    if matches:
+        return matches[0]
+    return "No explicit forward guidance language found in the available transcript excerpt."
+
+
+def _qa_text(text: str) -> str:
+    lower_text = text.lower()
+    for marker in ["question-and-answer", "question and answer", "q&a", "analyst q"]:
+        index = lower_text.find(marker)
+        if index >= 0:
+            return text[index:]
+    return text
+
+
+def analyze_transcript(ticker: str, transcript_text: str) -> dict[str, object] | None:
+    chunks = chunk_text(transcript_text, max_words=500, overlap_words=50)
+    if not chunks:
+        return None
+
+    relevant_chunks = retrieve_relevant_chunks(
+        chunks,
+        keywords=GUIDANCE_TERMS + RISK_TERMS + CATALYST_TERMS,
+        limit=5,
+    )
+    relevant_text = " ".join(relevant_chunks)
+    tone_score = _tone_score(relevant_text)
+    qa_score = _tone_score(_qa_text(transcript_text))
+    commentary = ManagementCommentary(
+        ticker=ticker.upper(),
+        tone_score=tone_score,
+        guidance_summary=_guidance_summary(relevant_text),
+        key_risks=_matching_sentences(relevant_text, RISK_TERMS, limit=3),
+        catalyst_flags=_matching_sentences(relevant_text, CATALYST_TERMS, limit=3),
+        analyst_qa_tone=_tone_label(qa_score),
+    )
+    return commentary.to_dict()

--- a/trg_workbench/llm/retriever.py
+++ b/trg_workbench/llm/retriever.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+
+def retrieve_relevant_chunks(
+    chunks: list[str],
+    keywords: list[str],
+    limit: int = 4,
+) -> list[str]:
+    if limit <= 0:
+        return []
+
+    normalized_keywords = [keyword.lower() for keyword in keywords]
+    scored: list[tuple[int, int, str]] = []
+    for index, chunk in enumerate(chunks):
+        lower_chunk = chunk.lower()
+        score = sum(lower_chunk.count(keyword) for keyword in normalized_keywords)
+        scored.append((score, -index, chunk))
+
+    matches = [item for item in scored if item[0] > 0]
+    if not matches:
+        return chunks[:limit]
+
+    matches.sort(reverse=True)
+    return [chunk for _, _, chunk in matches[:limit]]

--- a/trg_workbench/llm/transcript_fetcher.py
+++ b/trg_workbench/llm/transcript_fetcher.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import html
+import re
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from trg_workbench.config import CACHE_DIR, SEC_USER_AGENT
+from trg_workbench.io_utils import read_json, utc_now_iso, write_json
+from trg_workbench.sources.sec import SECClient
+
+
+SEC_FULL_TEXT_SEARCH_URL = "https://efts.sec.gov/LATEST/search-index"
+
+
+@dataclass
+class TranscriptDocument:
+    ticker: str
+    cik: str | None
+    accession_number: str | None
+    filing_date: str | None
+    source_url: str | None
+    text: str
+
+
+class SECEarningsTranscriptFetcher:
+    def __init__(
+        self,
+        cache_dir: Path | None = None,
+        user_agent: str = SEC_USER_AGENT,
+        session: requests.Session | None = None,
+    ) -> None:
+        self.cache_dir = cache_dir or CACHE_DIR / "transcripts"
+        self.session = session or requests.Session()
+        self.session.headers.update(
+            {
+                "User-Agent": user_agent,
+                "Accept": "application/json,text/html;q=0.9,*/*;q=0.8",
+            }
+        )
+
+    def _text_cache_path(self, ticker: str) -> Path:
+        return self.cache_dir / f"{ticker.upper()}_latest.txt"
+
+    def _metadata_cache_path(self, ticker: str) -> Path:
+        return self.cache_dir / f"{ticker.upper()}_latest.json"
+
+    def load_cached(self, ticker: str) -> TranscriptDocument | None:
+        text_path = self._text_cache_path(ticker)
+        metadata_path = self._metadata_cache_path(ticker)
+        if not text_path.exists():
+            return None
+        metadata = read_json(metadata_path) if metadata_path.exists() else {}
+        return TranscriptDocument(
+            ticker=ticker.upper(),
+            cik=metadata.get("cik"),
+            accession_number=metadata.get("accession_number"),
+            filing_date=metadata.get("filing_date"),
+            source_url=metadata.get("source_url"),
+            text=text_path.read_text(encoding="utf-8"),
+        )
+
+    def fetch_latest(
+        self,
+        ticker: str,
+        as_of_date: date,
+        refresh: bool = False,
+    ) -> TranscriptDocument | None:
+        ticker = ticker.upper()
+        cached = None if refresh else self.load_cached(ticker)
+        if cached:
+            return cached
+
+        cik = self._lookup_cik(ticker)
+        if not cik:
+            return None
+
+        hits = self._search_8k_hits(ticker, cik, as_of_date)
+        for hit in hits:
+            source_url = self._source_url(hit)
+            if not source_url:
+                continue
+            response = self.session.get(source_url, timeout=30)
+            response.raise_for_status()
+            text = clean_filing_text(response.text)
+            if not _looks_like_transcript(text):
+                continue
+            document = TranscriptDocument(
+                ticker=ticker,
+                cik=cik,
+                accession_number=_hit_value(hit, "accessionNo", "adsh"),
+                filing_date=_hit_value(hit, "file_date", "filedAt"),
+                source_url=source_url,
+                text=text,
+            )
+            self._write_cache(document)
+            return document
+        return None
+
+    def _lookup_cik(self, ticker: str) -> str | None:
+        ticker_map = SECClient(cache_dir=self.cache_dir.parent / "sec").fetch_ticker_map()
+        row = ticker_map.loc[ticker_map["ticker"].eq(ticker.upper())]
+        if row.empty:
+            return None
+        return str(row.iloc[0]["cik"]).zfill(10)
+
+    def _search_8k_hits(self, ticker: str, cik: str, as_of_date: date) -> list[dict[str, Any]]:
+        start_date = as_of_date - timedelta(days=540)
+        params = {
+            "q": f'"{ticker}" "earnings"',
+            "dateRange": "custom",
+            "startdt": start_date.isoformat(),
+            "enddt": as_of_date.isoformat(),
+            "forms": "8-K",
+            "ciks": cik,
+        }
+        response = self.session.get(SEC_FULL_TEXT_SEARCH_URL, params=params, timeout=30)
+        response.raise_for_status()
+        payload = response.json()
+        hits = payload.get("hits", {}).get("hits", [])
+        return hits if isinstance(hits, list) else []
+
+    def _source_url(self, hit: dict[str, Any]) -> str | None:
+        source = hit.get("_source", hit)
+        for key in ["linkToHtml", "linkToFilingDetails"]:
+            value = source.get(key)
+            if isinstance(value, str) and value:
+                return value if value.startswith("http") else f"https://www.sec.gov{value}"
+
+        accession = _hit_value(hit, "accessionNo", "adsh")
+        file_name = _hit_value(hit, "fileName", "file_name")
+        cik = _hit_value(hit, "cik") or _first_cik(source.get("ciks"))
+        if accession and file_name and cik:
+            accession_dir = accession.replace("-", "")
+            cik_dir = str(cik).lstrip("0")
+            return f"https://www.sec.gov/Archives/edgar/data/{cik_dir}/{accession_dir}/{file_name}"
+        return None
+
+    def _write_cache(self, document: TranscriptDocument) -> None:
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self._text_cache_path(document.ticker).write_text(document.text, encoding="utf-8")
+        write_json(
+            self._metadata_cache_path(document.ticker),
+            {
+                "ticker": document.ticker,
+                "cik": document.cik,
+                "accession_number": document.accession_number,
+                "filing_date": document.filing_date,
+                "source_url": document.source_url,
+                "retrieved_at": utc_now_iso(),
+            },
+        )
+
+
+def clean_filing_text(raw_html: str) -> str:
+    text = re.sub(r"(?is)<(script|style).*?>.*?</\1>", " ", raw_html or "")
+    text = re.sub(r"(?s)<[^>]+>", " ", text)
+    text = html.unescape(text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _looks_like_transcript(text: str) -> bool:
+    lower_text = text.lower()
+    transcript_terms = ["earnings", "conference call", "question-and-answer", "q&a", "operator"]
+    return sum(term in lower_text for term in transcript_terms) >= 2
+
+
+def _hit_value(hit: dict[str, Any], *keys: str) -> str | None:
+    source = hit.get("_source", hit)
+    for key in keys:
+        value = source.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def _first_cik(value: Any) -> str | None:
+    if isinstance(value, list) and value:
+        return str(value[0])
+    if isinstance(value, str) and value:
+        return value
+    return None

--- a/trg_workbench/pipeline_v2.py
+++ b/trg_workbench/pipeline_v2.py
@@ -13,6 +13,7 @@ New in v2:
 from __future__ import annotations
 
 import logging
+import os
 from datetime import datetime, date as _date_type
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -283,6 +284,30 @@ def build_research_report_v2(
         except Exception as exc:
             logger.warning("Valuation failed for %s: %s", ticker, exc)
 
+    # 2d. Management commentary from cached transcripts by default.
+    management_commentary: list[dict[str, object]] = []
+    if top3:
+        from trg_workbench.llm.pipeline import build_management_commentary
+
+        fetch_live_transcripts = os.getenv("TRG_FETCH_TRANSCRIPTS", "").lower() in {
+            "1",
+            "true",
+            "yes",
+        }
+        try:
+            management_commentary = build_management_commentary(
+                tickers=top3,
+                as_of_date=as_of_date,
+                fetch_live=fetch_live_transcripts,
+            )
+            if management_commentary:
+                write_json(
+                    NORMALIZED_DIR / f"management_commentary_{as_of}.json",
+                    management_commentary,
+                )
+        except Exception as exc:
+            logger.warning("Management commentary skipped: %s", exc)
+
     # ── 3. Generate charts (Target 2 Integration) ──────────────────────────
     logger.info("Generating research charts...")
     from trg_workbench.reporting.charts import build_research_charts
@@ -327,6 +352,7 @@ def build_research_report_v2(
         "sector_rows": sector_rows,
         "risk_rows": risk_rows,
         "dcf_results": dcf_results,
+        "management_commentary": management_commentary,
         "charts": charts,
         # ... (rest of context items)
     }

--- a/trg_workbench/reporting/templates/daily_note.md.j2
+++ b/trg_workbench/reporting/templates/daily_note.md.j2
@@ -47,6 +47,17 @@ Data as of: {{ as_of_date }}
 {% endfor %}
 
 {% endif %}
+{% if management_commentary %}
+## Management Commentary
+{% for row in management_commentary %}
+- {{ row.ticker }}: tone {{ row.tone_score | pct }}, guidance: {{ row.guidance_summary }}
+{% if row.key_risks %}  - Risks: {{ row.key_risks | join("; ") }}
+{% endif %}
+{% if row.catalyst_flags %}  - Catalysts: {{ row.catalyst_flags | join("; ") }}
+{% endif %}
+{% endfor %}
+
+{% endif %}
 {% if analyst_overlays %}
 ## Analyst Overlays
 {% for row in analyst_overlays %}

--- a/trg_workbench/reporting/templates/research_note.html.j2
+++ b/trg_workbench/reporting/templates/research_note.html.j2
@@ -659,6 +659,37 @@
 {% endif %}
 
 <!-- ═══════════════════════════════════════════════════════
+     MANAGEMENT COMMENTARY
+══════════════════════════════════════════════════════════ -->
+{% if management_commentary %}
+<h2 class="section-title">Management Commentary</h2>
+{% for row in management_commentary %}
+<h3 class="sub-title">{{ row.ticker }} — Transcript Read-Through</h3>
+<div class="metric-row">
+  <div class="metric-card">
+    <div class="mc-label">Management Tone</div>
+    <div class="mc-value">{{ row.tone_score | pct }}</div>
+    <div class="mc-sub">0% bearish / 100% bullish</div>
+  </div>
+  <div class="metric-card">
+    <div class="mc-label">Analyst Q&A Tone</div>
+    <div class="mc-value">{{ row.analyst_qa_tone | title }}</div>
+    <div class="mc-sub">{{ row.source }}</div>
+  </div>
+</div>
+<div class="exec-summary">
+  <p><strong>Guidance:</strong> {{ row.guidance_summary }}</p>
+  {% if row.key_risks %}
+  <p><strong>Key risks:</strong> {{ row.key_risks | join("; ") }}</p>
+  {% endif %}
+  {% if row.catalyst_flags %}
+  <p><strong>Catalysts:</strong> {{ row.catalyst_flags | join("; ") }}</p>
+  {% endif %}
+</div>
+{% endfor %}
+{% endif %}
+
+<!-- ═══════════════════════════════════════════════════════
      TACTICAL TAKEAWAYS
 ══════════════════════════════════════════════════════════ -->
 {% if tactical_takeaways %}


### PR DESCRIPTION
## Summary

Refs #9.

This PR adds the first safe slice of the earnings transcript reasoning layer:

- adds `trg_workbench/llm/` with transcript fetching, sentence-aware chunking, keyword retrieval, and deterministic management commentary extraction
- adds cache-first SEC 8-K transcript handling, with live fetching only when `TRG_FETCH_TRANSCRIPTS=1`
- writes management commentary into the v2 pipeline output when cached transcripts are available
- surfaces guidance, risks, catalysts, management tone, and Q&A tone in the HTML and Markdown research notes
- adds a fixture transcript and unit coverage with no live SEC request or live LLM call in CI

## Scope note

This intentionally does not close #9 yet. It avoids mandatory OpenAI keys, embeddings, FAISS/chromadb, and extra runtime dependencies in this first PR so the pipeline stays stable. The next slice can plug in an OpenAI/local LLM backend and vector retrieval behind the same module boundary.

## Validation

- `git diff --check`
- `python -m pytest -q` -> `14 passed`